### PR TITLE
Typo fix for foaf:depiction in SHACL files

### DIFF
--- a/releases/1.2.1/dcat-ap_1.2.1_shacl_mandatory-classes.shapes.ttl
+++ b/releases/1.2.1/dcat-ap_1.2.1_shacl_mandatory-classes.shapes.ttl
@@ -78,7 +78,7 @@
   owl:imports org: ;
   owl:imports foaf: ;
   owl:versionInfo "1.2.1" ;
-  foaf:depiction <hhttps://github.com/SEMICeu/DCAT-AP/blob/master/releases/1.2.1/DCAT-AP_1.2.1.png> ;
+  foaf:depiction <https://github.com/SEMICeu/DCAT-AP/blob/master/releases/1.2.1/DCAT-AP_1.2.1.png> ;
   foaf:homepage <http://data.europa.eu/w21/6be4d036-2e6d-4528-a888-0e9a0e29c579> ;
   foaf:logo <https://joinup.ec.europa.eu/sites/default/files/imagecache/community_logo/DCAT_application_profile_for_European_data_portals_logo_0.png> ;
   foaf:maker [

--- a/releases/1.2.1/dcat-ap_1.2.1_shacl_mdr-vocabularies.shape.ttl
+++ b/releases/1.2.1/dcat-ap_1.2.1_shacl_mdr-vocabularies.shape.ttl
@@ -82,7 +82,7 @@
   owl:imports org: ;
   owl:imports foaf: ;
   owl:versionInfo "1.2.1" ;
-  foaf:depiction <hhttps://github.com/SEMICeu/DCAT-AP/blob/master/releases/1.2.1/DCAT-AP_1.2.1.png> ;
+  foaf:depiction <https://github.com/SEMICeu/DCAT-AP/blob/master/releases/1.2.1/DCAT-AP_1.2.1.png> ;
   foaf:homepage <http://data.europa.eu/w21/6be4d036-2e6d-4528-a888-0e9a0e29c579> ;
   foaf:logo <https://joinup.ec.europa.eu/sites/default/files/imagecache/community_logo/DCAT_application_profile_for_European_data_portals_logo_0.png> ;
   foaf:maker [

--- a/releases/1.2.1/dcat-ap_1.2.1_shacl_shapes.ttl
+++ b/releases/1.2.1/dcat-ap_1.2.1_shacl_shapes.ttl
@@ -79,7 +79,7 @@
   owl:imports org: ;
   owl:imports foaf: ;
   owl:versionInfo "1.2.1" ;
-  foaf:depiction <hhttps://github.com/SEMICeu/DCAT-AP/blob/master/releases/1.2.1/DCAT-AP_1.2.1.png> ;
+  foaf:depiction <https://github.com/SEMICeu/DCAT-AP/blob/master/releases/1.2.1/DCAT-AP_1.2.1.png> ;
   foaf:homepage <http://data.europa.eu/w21/6be4d036-2e6d-4528-a888-0e9a0e29c579> ;
   foaf:logo <https://joinup.ec.europa.eu/sites/default/files/imagecache/community_logo/DCAT_application_profile_for_European_data_portals_logo_0.png> ;
   foaf:maker [


### PR DESCRIPTION
Typo for foaf:depiction in SHACL files. 
`hhttps` instead of `https`