### PR TITLE
fix bug dcatap prefix in shacl.ttl files

### DIFF
--- a/releases/1.2.1/dcat-ap_1.2.1_shacl_mdr-vocabularies.shape.ttl
+++ b/releases/1.2.1/dcat-ap_1.2.1_shacl_mdr-vocabularies.shape.ttl
@@ -19,7 +19,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 
 <http://data.europa.eu/r5r/mdr_shapes>

--- a/releases/2.0.0/dcat-ap_2.0.0_shacl_deprecateduris.ttl
+++ b/releases/2.0.0/dcat-ap_2.0.0_shacl_deprecateduris.ttl
@@ -18,7 +18,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 #-------------------------------------------------------------------------
 # The shapes in this file cover all URI changes that require attention

--- a/releases/2.0.0/dcat-ap_2.0.0_shacl_mdr-vocabularies.shape.ttl
+++ b/releases/2.0.0/dcat-ap_2.0.0_shacl_mdr-vocabularies.shape.ttl
@@ -19,7 +19,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 
 <http://data.europa.eu/r5r/mdr_shapes>

--- a/releases/2.0.0/dcat-ap_2.0.0_shacl_shapes.ttl
+++ b/releases/2.0.0/dcat-ap_2.0.0_shacl_shapes.ttl
@@ -19,7 +19,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 <http://data.europa.eu/r5r/shacl_shapes>
     dcat:accessURL <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/distribution/dcat-ap-200-shacl-shapes>;

--- a/releases/2.0.1/dcat-ap_2.0.1_shacl_deprecateduris.ttl
+++ b/releases/2.0.1/dcat-ap_2.0.1_shacl_deprecateduris.ttl
@@ -18,7 +18,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 #-------------------------------------------------------------------------
 # The shapes in this file cover all URI changes that require attention

--- a/releases/2.0.1/dcat-ap_2.0.1_shacl_mdr-vocabularies.shape.ttl
+++ b/releases/2.0.1/dcat-ap_2.0.1_shacl_mdr-vocabularies.shape.ttl
@@ -19,7 +19,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 
 <http://data.europa.eu/r5r/mdr_shapes>

--- a/releases/2.0.1/dcat-ap_2.0.1_shacl_shapes.ttl
+++ b/releases/2.0.1/dcat-ap_2.0.1_shacl_shapes.ttl
@@ -19,7 +19,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
 
 <http://data.europa.eu/r5r/shacl_shapes>
     dcat:accessURL <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/distribution/dcat-ap-200-shacl-shapes>;


### PR DESCRIPTION
Bug in shacl files. 

- **Wrong:** `@prefix dcatap: <http://data.europa.eu/r5r>` evaluates `dcatap:availability` as `http://data.europa.eu/r5ravailability` 

- **Right:** `@prefix dcatap: <http://data.europa.eu/r5r/>` evaluates `dcatap:availability` as   `http://data.europa.eu/r5r/availability`