### PR TITLE
SHACL / Unneeded empty property?

### DIFF
--- a/releases/3.0.0-draft/html/shacl/range.ttl
+++ b/releases/3.0.0-draft/html/shacl/range.ttl
@@ -390,7 +390,6 @@
     a sh:NodeShape ;
     rdfs:label "PeriodOfTime"@en ;
     sh:property [
-    ], [
         sh:class time:Instant ;
         sh:path time:hasBeginning ;
         sh:severity sh:Violation

--- a/releases/3.0.0-draft/html/shacl/shapes_recommended.ttl
+++ b/releases/3.0.0-draft/html/shacl/shapes_recommended.ttl
@@ -95,7 +95,6 @@
     a sh:NodeShape ;
     rdfs:label "Catalog Record"@en ;
     sh:property [
-    ], [
         sh:minCount 1 ;
         sh:path dct:conformsTo ;
         sh:severity sh:Warning
@@ -166,22 +165,16 @@
 :CategoryScheme_Shape
     a sh:NodeShape ;
     rdfs:label "Category Scheme"@en ;
-    sh:property [
-    ] ;
     sh:targetClass skos:ConceptScheme .
 
 :Category_Shape
     a sh:NodeShape ;
     rdfs:label "Category"@en ;
-    sh:property [
-    ] ;
     sh:targetClass skos:Concept .
 
 :Checksum_Shape
     a sh:NodeShape ;
     rdfs:label "Checksum"@en ;
-    sh:property [
-    ] ;
     sh:targetClass spdx:Checksum .
 
 :DataService_Shape
@@ -286,8 +279,6 @@
 :Identifier_Shape
     a sh:NodeShape ;
     rdfs:label "Identifier"@en ;
-    sh:property [
-    ] ;
     sh:targetClass adms:Identifier .
 
 :LicenceDocument_Shape
@@ -331,7 +322,5 @@
 :Relationship_Shape
     a sh:NodeShape ;
     rdfs:label "Relationship"@en ;
-    sh:property [
-    ] ;
     sh:targetClass dcat:Relationship .
 


### PR DESCRIPTION
We are trying to reproduce the SHACL validation report of https://www.itb.ec.europa.eu/shacl/dcat-ap/upload

The configuration is based on https://github.com/ISAITB/validator-resources-dcat-ap/blob/master/resources/config.properties#L117-L128

But running SHACL validation using Jena does not produce same validation results.

A first issue is related to empty property. Jena fails to parse SHACL shapes:

```
Missing property shape: 
node=<https://semiceu.github.io/DCAT-AP/releases/3.0.0/html/shacl/range.ttl#PeriodOfTime_Shape> 
sh:property _:B29af15d3d4515d6426fd22552bbc0a96
```
due to:
```
sh:property [], [
```