### PR TITLE
SHACL / Missing `sh:path` in rules?

### DIFF
--- a/releases/3.0.0-draft/html/shacl/range.ttl
+++ b/releases/3.0.0-draft/html/shacl/range.ttl
@@ -419,7 +419,7 @@
     a sh:NodeShape ;
     rdfs:label "Dataset Series"@en ;
     sh:property [
-       sh:inversePath dcat:inSeries;
+       sh:path [sh:inversePath dcat:inSeries;];
        sh:severity sh:Warning
     ], [
   	sh:path dcatap:applicableLegislation;

--- a/releases/3.0.0-draft/html/shacl/shapes.ttl
+++ b/releases/3.0.0-draft/html/shacl/shapes.ttl
@@ -302,7 +302,8 @@
         sh:severity sh:Violation
     ], [
         sh:nodeKind sh:IRI ;
-  	sh:class <http://data.europa.eu/eli/ontology#LegalResource>;
+        sh:path dcatap:applicableLegislation ;
+        sh:class <http://data.europa.eu/eli/ontology#LegalResource>;
         sh:severity sh:Violation
     ], [
         sh:nodeKind sh:BlankNodeOrIRI ;
@@ -692,7 +693,7 @@
     sh:property [
         sh:minCount 1;
         sh:nodeKind sh:BlankNodeOrIRI;
-        sh:inversePath dcat:inSeries;
+        sh:path [ sh:inversePath dcat:inSeries; ];
         sh:severity sh:Warning
     ], [
   	sh:nodeKind sh:IRI;


### PR DESCRIPTION
Jena fails to parse SHACL shapes due to missing `path`:
```
No sh:path on a property shape: 
node=<https://semiceu.github.io/DCAT-AP/releases/3.0.0/html/shacl/shapes.ttl#DatasetSeries_Shape> 
sh:property _:B1f2b5d2b47a093d15d2dd175eb75559e
```

Probably related to https://github.com/apache/jena/issues/2129

Intellij also report an error on those rules:
```
Invalid cardinality: expected min 1: Got count = 0
Broader shape:
shsh:PropertyShapeShape
Shape:
[__:o:9683 in shsh.ttl]
Path:
sh:path
SHACL:
sh:path
Component:
sh:MinCountConstraintComponent
```

![image](https://github.com/SEMICeu/DCAT-AP/assets/1701393/7ed8067e-942d-4591-b4a5-078a8918d935)


For the series, I'm not 100% sure
`sh:inversePath dcat:inSeries;` and `sh:path [ sh:inversePath dcat:inSeries; ];` are equivalent.

Also when validating a series only, this rule will always fails when the dataset is not in the graph - but that's another discussion.