### PR TITLE
Use consistent hyphenation for High-Value Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The specification of the DCAT-AP was a joint initiative of DG CONNECT, the EU Pu
 The latest version of DCAT-AP (SEMIC Recommendation v3.0.1) can be downloaded from from the [releases](https://github.com/SEMICeu/DCAT-AP/releases) or via [JoinUp](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/releases).
 The HTML of this specification can be found [here](https://semiceu.github.io/DCAT-AP/releases/3.0.1/).
 
-The latest version of DCAT-AP Annex for High Value Datasets (SEMIC Recommendation v3.0.0) is also published [here](https://semiceu.github.io/DCAT-AP/releases/3.0.0-hvd/).
+The latest version of DCAT-AP Annex for High-Value Datasets (SEMIC Recommendation v3.0.0) is also published [here](https://semiceu.github.io/DCAT-AP/releases/3.0.0-hvd/).
 
 
 Any problems encountered, or suggestions for new functionalities can be submitted as issues on the DCAT-AP repository on GitHub. A short guideline for submitting issues can be found at https://github.com/SEMICeu/DCAT-AP/wiki/Submission-guidelines.

--- a/releases/2.2.0-hvd/CHANGELOG
+++ b/releases/2.2.0-hvd/CHANGELOG
@@ -1,5 +1,5 @@
 10-03-2023
-  Initialize the DCAT-AP Annex for High Value Datasets
+  Initialize the DCAT-AP Annex for High-Value Datasets
 19-06-2023
   Publication of candidate release based on the outcomes of the two webinars.
 14-12-2023

--- a/releases/2.2.0-hvd/index.html
+++ b/releases/2.2.0-hvd/index.html
@@ -7,7 +7,7 @@
     
 	
     <meta charset="utf-8" />
-    <title>DCAT-AP High Value Datasets</title>
+    <title>DCAT-AP High-Value Datasets</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
     // All config options at https://respec.org/docs/
@@ -104,7 +104,7 @@
       editors: myeditors,
       authors: myauthors,
       github: "SEMICeu/DCAT-AP",
-      shortName: "DCAT-AP High Value Datasets",
+      shortName: "DCAT-AP High-Value Datasets",
       xref: "web-platform",
       doJsonLd: true,
       logos: [{
@@ -170,7 +170,7 @@
          },
         "HVD" : {
            "href":"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0138",
-           "title" : "Implementing Regulation for High Value Datasets",
+           "title" : "Implementing Regulation for High-Value Datasets",
            "publisher":"European Commission"
         },
         "BCP4715" : {

--- a/releases/3.0.0-hvd/index.html
+++ b/releases/3.0.0-hvd/index.html
@@ -7,7 +7,7 @@
     
 	
     <meta charset="utf-8" />
-    <title>DCAT-AP High Value Datasets</title>
+    <title>DCAT-AP High-Value Datasets</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
     // All config options at https://respec.org/docs/
@@ -147,7 +147,7 @@
         
       ],
       github: "SEMICeu/DCAT-AP",
-      shortName: "DCAT-AP High Value Datasets",
+      shortName: "DCAT-AP High-Value Datasets",
       xref: "web-platform",
       doJsonLd: true,
       logos: [{
@@ -214,7 +214,7 @@
          },
         "HVD" : {
            "href":"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0138",
-           "title" : "Implementing Regulation for High Value Datasets",
+           "title" : "Implementing Regulation for High-Value Datasets",
            "publisher":"European Commission"
         },
         "BCP4715" : {
@@ -3603,7 +3603,7 @@ The HVD IR defines six thematic data categories: geospatial, earth observation a
 A new property <a href="http://data.europa.eu/r5r/hvdCategory">HVD category</a> is introduced to indicate the HVD category to which an resource, i.e. a dataset, belongs.
 The controlled vocabulary <a href="https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/high-value-dataset-category">High-value dataset categories</a> with all possible values is maintained by the Publications Office.
 A resource may belong to more than one data category.
-It is recommended to annotate the High Value Datasets with the most precise concept.
+It is recommended to annotate the High-Value Datasets with the most precise concept.
 
 
 

--- a/releases/3.0.0/CHANGELOG.md
+++ b/releases/3.0.0/CHANGELOG.md
@@ -21,7 +21,7 @@ This Changelog provides an overview of the changes incorporated in DCAT-AP 3.0.0
 - Agent roles: added paragraph to cross-reference to the guidelines in DCAT 3.
 - Accessibility and Multilingual Aspects: no change.
 - Usage guide on Datasets, Distributions and Data Services: integrated this GitHub located section in the document.
-- High Value Datasets: new section to create a reference to the guidelines for High Value Datasets.
+- High-Value Datasets: new section to create a reference to the guidelines for High-Value Datasets.
 - Validation of DCAT-AP: integrated this GitHub located section in the document.
 - Example Dataset Series: new section containing examples for Dataset Series.
 - Inverse properties: new section on the handling of inverse properties.

--- a/releases/3.0.0/index.html
+++ b/releases/3.0.0/index.html
@@ -174,7 +174,7 @@
         },
 		"HVD" : {
 		  "href":"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0138",
-		  "title":"Implementing Regulation for High Value Datasets",
+		  "title":"Implementing Regulation for High-Value Datasets",
 		  "publisher":"European Union"
 		},
 		"DCAT-AP-HVD" : {
@@ -10050,7 +10050,7 @@ In addition to the proposed common controlled vocabularies, which are mandatory 
 Providing correct and sufficient legal information is important to create trust by candidate reusers.
 Without explicit legal information there is a risk involved in the reuse of data, because one has no way of knowing what is allowed. 
 While in the past legislation and initiatives such as Findable, Accessible, Interoperable and Reusable [[FAIR]] data stress the importance of this information, 
-recent legislations, such as the <a href="https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj">High Value Datasets regulation</a>, have become more demanding by imposing a minimum level of reuse.
+recent legislations, such as the <a href="https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj">High-Value Datasets regulation</a>, have become more demanding by imposing a minimum level of reuse.
 As a general principle, it is recommended that publishers consult their legal services to provide the appropriate values.
 
 <p></p>
@@ -10251,7 +10251,7 @@ For instance, a usual adaption is the addition of the release data in the title.
 </section>
 
   <section class="informative">
-<h2>High Value Datasets</h2>
+<h2>High-Value Datasets</h2>
 
 <p>
 In light of the growing importance of data, the European Commission has adopted an <href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0138">implementing regulation</a> focused on high-value datasets on 21 December 2022 [[HVD]]. 

--- a/releases/3.0.1/index.html
+++ b/releases/3.0.1/index.html
@@ -215,7 +215,7 @@
         },
 		"HVD" : {
 		  "href":"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0138",
-		  "title":"Implementing Regulation for High Value Datasets",
+		  "title":"Implementing Regulation for High-Value Datasets",
 		  "publisher":"European Union"
 		},
 		"DCAT-AP-HVD" : {
@@ -10405,7 +10405,7 @@ In addition to the proposed common controlled vocabularies, which are mandatory 
 Providing correct and sufficient legal information is important to create trust by candidate reusers.
 Without explicit legal information there is a risk involved in the reuse of data, because one has no way of knowing what is allowed. 
 While in the past legislation and initiatives such as Findable, Accessible, Interoperable and Reusable [[FAIR]] data stress the importance of this information, 
-recent legislations, such as the <a href="https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj">High Value Datasets regulation</a>, have become more demanding by imposing a minimum level of reuse.
+recent legislations, such as the <a href="https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj">High-Value Datasets regulation</a>, have become more demanding by imposing a minimum level of reuse.
 As a general principle, it is recommended that publishers consult their legal services to provide the appropriate values.
 
 <p></p>
@@ -10621,7 +10621,7 @@ To forster the sharing of experiences and insights this section lists known DCAT
 <h3>European DCAT-AP profiles</h3>
 <ul>
 <li> DCAT-AP: the base European profile DCAT-AP, <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.1">https://semiceu.github.io/DCAT-AP/releases/3.0.1</a> </li>
-<li> DCAT-AP HVD: DCAT-AP for High Value Datasets <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.0-hvd/">https://semiceu.github.io/DCAT-AP/releases/3.0.0-hvd/ </a> </li>
+<li> DCAT-AP HVD: DCAT-AP for High-Value Datasets <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.0-hvd/">https://semiceu.github.io/DCAT-AP/releases/3.0.0-hvd/ </a> </li>
 <li> GeoDCAT-AP: DCAT-AP for geospatial datasets  <a href="https://semiceu.github.io/GeoDCAT-AP/releases/3.0.0">https://semiceu.github.io/GeoDCAT-AP/releases/3.0.0 </a> </li>
 <li> StatDCAT-AP: DCAT-AP for statistical datasets  <a href="https://github.com/SEMICeu/StatDCAT-AP">https://github.com/SEMICeu/StatDCAT-AP </a> </li>
 <li> Health DCAT-AP: DCAT-AP for health datasets <a href="https://healthdcat-ap.github.io/">https://healthdcat-ap.github.io/ </a> </li>
@@ -10642,7 +10642,7 @@ We invite EU MSs to share the references to their DCAT-AP profiles. This can be 
 </section>
 
   <section class="informative">
-<h2>High Value Datasets</h2>
+<h2>High-Value Datasets</h2>
 
 <p>
 In light of the growing importance of data, the European Commission has adopted an <href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0138">implementing regulation</a> focused on high-value datasets on 21 December 2022 [[HVD]]. 


### PR DESCRIPTION
Fixes #482.

- Update the annex/profile title to ‘High-Value Datasets’.
- Replace remaining occurrences of ‘High Value Datasets’ with the hyphenated form across the published release HTML and changelog where it appears.

No functional changes; terminology alignment only.